### PR TITLE
fix: Cloudflare scaffold env와 tRPC workspace 해석 회귀 수정

### DIFF
--- a/.changeset/mean-mayflies-yawn.md
+++ b/.changeset/mean-mayflies-yawn.md
@@ -2,4 +2,4 @@
 create-rn-miniapp: patch
 ---
 
-Cloudflare server scaffold가 `frontend/.env.local`, `backoffice/.env.local` placeholder를 자동으로 만들고, Worker URL을 자동으로 채우지 못한 경우 안내 문구도 값 입력 중심으로 정리했어요.
+Cloudflare server scaffold가 `frontend/.env.local`, `backoffice/.env.local` placeholder를 자동으로 만들고, Worker URL을 자동으로 채우지 못한 경우 안내 문구도 값 입력 중심으로 정리했어요. tRPC shared package도 `package.json` export와 shared TypeScript dependency를 같이 넣어 RN `ait build`에서 workspace package 해석이 끊기지 않게 맞췄어요.

--- a/.changeset/mean-mayflies-yawn.md
+++ b/.changeset/mean-mayflies-yawn.md
@@ -1,0 +1,5 @@
+---
+create-rn-miniapp: patch
+---
+
+Cloudflare server scaffold가 `frontend/.env.local`, `backoffice/.env.local` placeholder를 자동으로 만들고, Worker URL을 자동으로 채우지 못한 경우 안내 문구도 값 입력 중심으로 정리했어요.

--- a/docs/ai/Plan.md
+++ b/docs/ai/Plan.md
@@ -1,3 +1,15 @@
+## 다음 작업: Cloudflare+tRPC shared workspace package export 회귀 수정
+
+### 목표
+- Cloudflare+tRPC scaffold가 생성하는 `packages/contracts`, `packages/app-router`가 AIT dependency version 수집 단계에서도 안정적으로 해석되게 만든다.
+- `packages/app-router` root import 구조는 유지하되, generated shared package의 `package.json` export와 dev dependency contract를 테스트로 먼저 고정한다.
+- 관련 템플릿 테스트와 실제 scaffold 재현, `pnpm verify`로 회귀가 없는지 확인한다.
+
+### 작업 순서
+1. tRPC workspace template 테스트에 shared package `exports["./package.json"]`와 `typescript` devDependency 기대값을 먼저 추가한다.
+2. `packages/create-rn-miniapp/src/templates/trpc.ts`에서 `contracts`, `app-router` package template이 같은 export/devDependency contract를 렌더하도록 수정한다.
+3. fresh scaffold 재현으로 `frontend build`를 다시 확인하고, `pnpm verify`까지 돌려 최종 상태를 검증한다.
+
 ## 다음 작업: Cloudflare scaffold client env placeholder 누락 수정
 
 ### 목표

--- a/docs/ai/Plan.md
+++ b/docs/ai/Plan.md
@@ -1,3 +1,15 @@
+## 다음 작업: Cloudflare scaffold client env placeholder 누락 수정
+
+### 목표
+- Cloudflare server provider를 붙인 scaffold가 원격 프로비저닝을 건너뛰더라도 `frontend/.env.local`, `backoffice/.env.local` placeholder를 남기게 만든다.
+- provider bootstrap이 요구하는 env contract와 실제 generated 파일 상태를 테스트로 먼저 고정한다.
+- 관련 테스트와 `pnpm verify`로 회귀가 없는지 확인한다.
+
+### 작업 순서
+1. `patchFrontendWorkspace`, `patchBackofficeWorkspace` 테스트에 Cloudflare placeholder `.env.local` 생성 기대값을 먼저 추가한다.
+2. provider bootstrap 단계에서 기존 env 파일은 보존하면서 누락된 `.env.local`만 provider별 blank key로 채우는 helper를 넣는다.
+3. 타깃 테스트 후 `pnpm verify`를 실행해 scaffold/provider 회귀가 없는지 확인한다.
+
 ## 다음 작업: 추천 agent skills 설치 시 tds-ui metadata ENOENT 회귀 수정
 
 ### 목표

--- a/packages/create-rn-miniapp/src/patching/backoffice.ts
+++ b/packages/create-rn-miniapp/src/patching/backoffice.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import type { ServerProvider } from '../providers/index.js'
-import { removePathIfExists, writeWorkspaceNpmrc } from '../templates/filesystem.js'
+import { pathExists, removePathIfExists, writeWorkspaceNpmrc } from '../templates/filesystem.js'
 import { applyWorkspaceProjectTemplate } from '../templates/server.js'
 import type { TemplateTokens } from '../templates/types.js'
 import {
@@ -71,6 +71,25 @@ const BACKOFFICE_FIREBASE_ENV_TYPES = dedentWithTrailingNewline`
     readonly env: ImportMetaEnv
   }
 `
+
+const BACKOFFICE_PROVIDER_ENV_PLACEHOLDERS: Partial<Record<ServerProvider, string>> = {
+  supabase: dedentWithTrailingNewline`
+    VITE_SUPABASE_URL=
+    VITE_SUPABASE_PUBLISHABLE_KEY=
+  `,
+  cloudflare: dedentWithTrailingNewline`
+    VITE_API_BASE_URL=
+  `,
+  firebase: dedentWithTrailingNewline`
+    VITE_FIREBASE_API_KEY=
+    VITE_FIREBASE_AUTH_DOMAIN=
+    VITE_FIREBASE_PROJECT_ID=
+    VITE_FIREBASE_STORAGE_BUCKET=
+    VITE_FIREBASE_MESSAGING_SENDER_ID=
+    VITE_FIREBASE_APP_ID=
+    VITE_FIREBASE_MEASUREMENT_ID=
+  `,
+}
 
 const BACKOFFICE_SUPABASE_CLIENT = dedentWithTrailingNewline`
   import { createClient, type SupabaseClient } from '@supabase/supabase-js'
@@ -237,6 +256,29 @@ async function writeBackofficeFirebaseBootstrap(backofficeRoot: string) {
   )
 }
 
+async function ensureBackofficeLocalEnvPlaceholder(
+  backofficeRoot: string,
+  serverProvider: ServerProvider | null,
+) {
+  if (!serverProvider) {
+    return
+  }
+
+  const envPlaceholder = BACKOFFICE_PROVIDER_ENV_PLACEHOLDERS[serverProvider]
+
+  if (!envPlaceholder) {
+    return
+  }
+
+  const envPath = path.join(backofficeRoot, '.env.local')
+
+  if (await pathExists(envPath)) {
+    return
+  }
+
+  await writeTextFile(envPath, envPlaceholder)
+}
+
 async function ensureBackofficePackageJsonForWorkspace(
   backofficeRoot: string,
   packageJson: PackageJson,
@@ -356,6 +398,7 @@ export async function ensureBackofficeSupabaseBootstrap(
   ])
   await patchBackofficeEntryFiles(backofficeRoot)
   await writeBackofficeSupabaseBootstrap(backofficeRoot)
+  await ensureBackofficeLocalEnvPlaceholder(backofficeRoot, 'supabase')
   await applyWorkspaceProjectTemplate(targetRoot, 'backoffice', tokens)
 }
 
@@ -380,6 +423,7 @@ export async function ensureBackofficeCloudflareBootstrap(
   ])
   await patchBackofficeEntryFiles(backofficeRoot)
   await writeBackofficeCloudflareBootstrap(backofficeRoot)
+  await ensureBackofficeLocalEnvPlaceholder(backofficeRoot, 'cloudflare')
   await applyWorkspaceProjectTemplate(targetRoot, 'backoffice', tokens)
 }
 
@@ -404,6 +448,7 @@ export async function ensureBackofficeFirebaseBootstrap(
   ])
   await patchBackofficeEntryFiles(backofficeRoot)
   await writeBackofficeFirebaseBootstrap(backofficeRoot)
+  await ensureBackofficeLocalEnvPlaceholder(backofficeRoot, 'firebase')
   await applyWorkspaceProjectTemplate(targetRoot, 'backoffice', tokens)
 }
 
@@ -476,6 +521,8 @@ export async function patchBackofficeWorkspace(
   if (options.serverProvider === 'firebase') {
     await writeBackofficeFirebaseBootstrap(backofficeRoot)
   }
+
+  await ensureBackofficeLocalEnvPlaceholder(backofficeRoot, options.serverProvider)
 
   await applyWorkspaceProjectTemplate(targetRoot, 'backoffice', tokens)
 }

--- a/packages/create-rn-miniapp/src/patching/frontend.ts
+++ b/packages/create-rn-miniapp/src/patching/frontend.ts
@@ -80,6 +80,26 @@ const FRONTEND_FIREBASE_ENV_TYPES = dedentWithTrailingNewline`
   }
 `
 
+const FRONTEND_PROVIDER_ENV_PLACEHOLDERS: Partial<Record<ServerProvider, string>> = {
+  supabase: dedentWithTrailingNewline`
+    MINIAPP_SUPABASE_URL=
+    MINIAPP_SUPABASE_PUBLISHABLE_KEY=
+  `,
+  cloudflare: dedentWithTrailingNewline`
+    MINIAPP_API_BASE_URL=
+  `,
+  firebase: dedentWithTrailingNewline`
+    MINIAPP_FIREBASE_API_KEY=
+    MINIAPP_FIREBASE_AUTH_DOMAIN=
+    MINIAPP_FIREBASE_PROJECT_ID=
+    MINIAPP_FIREBASE_STORAGE_BUCKET=
+    MINIAPP_FIREBASE_MESSAGING_SENDER_ID=
+    MINIAPP_FIREBASE_APP_ID=
+    MINIAPP_FIREBASE_MEASUREMENT_ID=
+    MINIAPP_FIREBASE_FUNCTION_REGION=
+  `,
+}
+
 const FRONTEND_SUPABASE_CLIENT = dedentWithTrailingNewline`
   import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
@@ -649,6 +669,29 @@ async function writeFrontendFirebaseBootstrap(frontendRoot: string) {
   )
 }
 
+async function ensureFrontendLocalEnvPlaceholder(
+  frontendRoot: string,
+  serverProvider: ServerProvider | null,
+) {
+  if (!serverProvider) {
+    return
+  }
+
+  const envPlaceholder = FRONTEND_PROVIDER_ENV_PLACEHOLDERS[serverProvider]
+
+  if (!envPlaceholder) {
+    return
+  }
+
+  const envPath = path.join(frontendRoot, '.env.local')
+
+  if (await pathExists(envPath)) {
+    return
+  }
+
+  await writeTextFile(envPath, envPlaceholder)
+}
+
 async function ensureFrontendPackageJsonForWorkspace(
   frontendRoot: string,
   packageJson: PackageJson,
@@ -752,6 +795,7 @@ export async function ensureFrontendSupabaseBootstrap(targetRoot: string, tokens
     },
   ])
   await writeFrontendSupabaseBootstrap(frontendRoot)
+  await ensureFrontendLocalEnvPlaceholder(frontendRoot, 'supabase')
   await applyWorkspaceProjectTemplate(targetRoot, 'frontend', tokens)
 }
 
@@ -777,6 +821,7 @@ export async function ensureFrontendCloudflareBootstrap(
     },
   ])
   await writeFrontendCloudflareBootstrap(frontendRoot)
+  await ensureFrontendLocalEnvPlaceholder(frontendRoot, 'cloudflare')
   await applyWorkspaceProjectTemplate(targetRoot, 'frontend', tokens)
 }
 
@@ -799,6 +844,7 @@ export async function ensureFrontendFirebaseBootstrap(targetRoot: string, tokens
     },
   ])
   await writeFrontendFirebaseBootstrap(frontendRoot)
+  await ensureFrontendLocalEnvPlaceholder(frontendRoot, 'firebase')
   await applyWorkspaceProjectTemplate(targetRoot, 'frontend', tokens)
 }
 
@@ -872,6 +918,8 @@ export async function patchFrontendWorkspace(
     await ensureFrontendFirebaseCryptoShim(frontendRoot)
     await writeFrontendFirebaseBootstrap(frontendRoot)
   }
+
+  await ensureFrontendLocalEnvPlaceholder(frontendRoot, options.serverProvider)
 
   await applyWorkspaceProjectTemplate(targetRoot, 'frontend', tokens)
 }

--- a/packages/create-rn-miniapp/src/patching/index.test.ts
+++ b/packages/create-rn-miniapp/src/patching/index.test.ts
@@ -705,6 +705,7 @@ test('patchFrontendWorkspace adds cloudflare API bootstrap when cloudflare serve
   }
   const graniteConfig = await readFile(path.join(frontendRoot, 'granite.config.ts'), 'utf8')
   const granitePreset = await readFile(path.join(frontendRoot, 'scaffold.preset.ts'), 'utf8')
+  const envFile = await readFile(path.join(frontendRoot, '.env.local'), 'utf8')
   const envTypes = await readFile(path.join(frontendRoot, 'src', 'env.d.ts'), 'utf8')
   const apiClient = await readFile(path.join(frontendRoot, 'src', 'lib', 'api.ts'), 'utf8')
 
@@ -730,6 +731,7 @@ test('patchFrontendWorkspace adds cloudflare API bootstrap when cloudflare serve
     granitePreset,
     /export const scaffoldEnvBindings = \{ MINIAPP_API_BASE_URL: miniappApiBaseUrl \}/,
   )
+  assert.equal(envFile, 'MINIAPP_API_BASE_URL=\n')
   assert.match(envTypes, /readonly MINIAPP_API_BASE_URL: string/)
   assert.match(apiClient, /import\.meta\.env\.MINIAPP_API_BASE_URL/)
   assert.match(apiClient, /export async function apiFetch/)
@@ -804,6 +806,7 @@ test('patchFrontendWorkspace adds cloudflare trpc client when trpc overlay is se
       noEmit?: boolean
     }
   }
+  const envFile = await readFile(path.join(frontendRoot, '.env.local'), 'utf8')
   const trpcClient = await readFile(path.join(frontendRoot, 'src', 'lib', 'trpc.ts'), 'utf8')
 
   assert.equal(packageJson.dependencies?.['@trpc/client'], '^11.13.4')
@@ -815,6 +818,7 @@ test('patchFrontendWorkspace adds cloudflare trpc client when trpc overlay is se
   assert.equal(tsconfig.compilerOptions?.allowImportingTsExtensions, true)
   assert.equal(tsconfig.compilerOptions?.moduleResolution, 'bundler')
   assert.equal(tsconfig.compilerOptions?.noEmit, true)
+  assert.equal(envFile, 'MINIAPP_API_BASE_URL=\n')
   assert.equal(await pathExists(path.join(frontendRoot, 'src', 'lib', 'api.ts')), false)
   assert.match(trpcClient, /createTRPCProxyClient/)
   assert.match(trpcClient, /import type \{ AppRouter \} from '@workspace\/app-router'/)
@@ -1376,10 +1380,12 @@ test('patchBackofficeWorkspace adds cloudflare API bootstrap when cloudflare ser
   ) as {
     dependencies?: Record<string, string>
   }
+  const envFile = await readFile(path.join(backofficeRoot, '.env.local'), 'utf8')
   const envTypes = await readFile(path.join(backofficeRoot, 'src', 'vite-env.d.ts'), 'utf8')
   const apiClient = await readFile(path.join(backofficeRoot, 'src', 'lib', 'api.ts'), 'utf8')
 
   assert.equal(packageJson.dependencies?.['@supabase/supabase-js'], undefined)
+  assert.equal(envFile, 'VITE_API_BASE_URL=\n')
   assert.match(envTypes, /readonly VITE_API_BASE_URL: string/)
   assert.match(apiClient, /import\.meta\.env\.VITE_API_BASE_URL/)
   assert.match(apiClient, /export async function apiFetch/)
@@ -1656,6 +1662,7 @@ test('patchBackofficeWorkspace adds cloudflare trpc client without api helper wh
     dependencies?: Record<string, string>
     devDependencies?: Record<string, string>
   }
+  const envFile = await readFile(path.join(backofficeRoot, '.env.local'), 'utf8')
   const trpcClient = await readFile(path.join(backofficeRoot, 'src', 'lib', 'trpc.ts'), 'utf8')
 
   assert.equal(packageJson.dependencies?.['@trpc/client'], '^11.13.4')
@@ -1664,6 +1671,7 @@ test('patchBackofficeWorkspace adds cloudflare trpc client without api helper wh
     packageJson.scripts?.typecheck,
     'pnpm --dir ../packages/app-router run build && tsc -b --pretty false',
   )
+  assert.equal(envFile, 'VITE_API_BASE_URL=\n')
   assert.equal(await pathExists(path.join(backofficeRoot, 'src', 'lib', 'api.ts')), false)
   assert.match(trpcClient, /createTRPCProxyClient/)
   assert.match(trpcClient, /import type \{ AppRouter \} from '@workspace\/app-router'/)

--- a/packages/create-rn-miniapp/src/patching/server.ts
+++ b/packages/create-rn-miniapp/src/patching/server.ts
@@ -588,7 +588,7 @@ function renderCloudflareServerReadme(options?: {
     
     - miniapp frontend \`.env.local\`은 \`${contract.frontend.envFile}\`에 두고 ${formatEnvKeys(contract.frontend.envKeys)}를 사용해요.
     - backoffice \`.env.local\`은 \`${contract.backoffice.envFile}\`에 두고 ${formatEnvKeys(contract.backoffice.envKeys)}를 사용해요.
-    - provisioning이 성공하면 frontend/backoffice \`.env.local\`에 Worker URL이 자동으로 기록돼요.
+    - scaffold가 frontend/backoffice \`.env.local\` placeholder를 자동으로 만들고, provisioning이 성공하면 Worker URL까지 자동으로 기록해요.
     - Worker 코드는 \`${CLOUDFLARE_D1_BINDING_NAME}\` D1 binding과 \`${CLOUDFLARE_R2_BINDING_NAME}\` R2 binding을 사용할 수 있어요.
     ${
       trpcEnabled

--- a/packages/create-rn-miniapp/src/providers/cloudflare/provision.test.ts
+++ b/packages/create-rn-miniapp/src/providers/cloudflare/provision.test.ts
@@ -225,14 +225,15 @@ test('formatCloudflareManualSetupNote includes frontend and backoffice env guida
     r2BucketName: 'ebook-storage',
   })
 
-  assert.equal(note.title, 'Cloudflare API URL을 이렇게 넣어 주세요')
+  assert.equal(note.title, 'Cloudflare Worker URL만 채워 주세요')
   assert.match(note.body, /frontend\/\.env\.local/)
   assert.match(note.body, /backoffice\/\.env\.local/)
   assert.match(note.body, /server\/\.env\.local/)
   assert.match(note.body, /CLOUDFLARE_D1_DATABASE_ID=database-123/)
   assert.match(note.body, /CLOUDFLARE_R2_BUCKET_NAME=ebook-storage/)
-  assert.match(note.body, /MINIAPP_API_BASE_URL=<배포된 Worker URL>/)
-  assert.match(note.body, /VITE_API_BASE_URL=<배포된 Worker URL>/)
+  assert.match(note.body, /placeholder는 자동으로 만들었어요/)
+  assert.doesNotMatch(note.body, /MINIAPP_API_BASE_URL=<배포된 Worker URL>/)
+  assert.doesNotMatch(note.body, /VITE_API_BASE_URL=<배포된 Worker URL>/)
   assert.match(note.body, /## Cloudflare API token/)
   assert.match(note.body, /CLOUDFLARE_API_TOKEN=/)
   assert.match(note.body, /Edit Cloudflare Workers/)
@@ -449,10 +450,12 @@ test('finalizeCloudflareProvisioning falls back to manual setup guidance when ap
 
     const serverEnv = await readFile(path.join(targetRoot, 'server', '.env.local'), 'utf8')
 
-    assert.equal(notes[0]?.title, 'Cloudflare API URL을 이렇게 넣어 주세요')
+    assert.equal(notes[0]?.title, 'Cloudflare Worker URL만 채워 주세요')
     assert.match(notes[0]?.body ?? '', /ebook-miniapp/)
     assert.match(notes[0]?.body ?? '', /frontend\/\.env\.local/)
+    assert.match(notes[0]?.body ?? '', /placeholder는 자동으로 만들었어요/)
     assert.match(notes[0]?.body ?? '', /server\/\.env\.local/)
+    assert.doesNotMatch(notes[0]?.body ?? '', /MINIAPP_API_BASE_URL=<배포된 Worker URL>/)
     assert.match(serverEnv, /^CLOUDFLARE_ACCOUNT_ID=account-123$/m)
     assert.match(serverEnv, /^CLOUDFLARE_D1_DATABASE_ID=database-123$/m)
   } finally {

--- a/packages/create-rn-miniapp/src/providers/cloudflare/provision.ts
+++ b/packages/create-rn-miniapp/src/providers/cloudflare/provision.ts
@@ -877,13 +877,9 @@ export function formatCloudflareManualSetupNote(options: {
           기존 Cloudflare Worker를 골라서 원격 초기화는 자동으로 건너뛰었어요.
         `
       : ''
-  const backofficeBlock = options.hasBackoffice
-    ? dedent`
-
-        ${path.join(options.targetRoot, 'backoffice', '.env.local')}
-        VITE_API_BASE_URL=<배포된 Worker URL>
-      `
-    : ''
+  const clientEnvGuidance = options.hasBackoffice
+    ? 'frontend/.env.local 과 backoffice/.env.local placeholder는 자동으로 만들었어요.'
+    : 'frontend/.env.local placeholder는 자동으로 만들었어요.'
   const tokenGuideBlock = renderOptionalMarkdownLines(buildCloudflareApiTokenGuideLines())
   const serverEnv = createCloudflareServerEnvValues({
     accountId: options.accountId,
@@ -895,12 +891,10 @@ export function formatCloudflareManualSetupNote(options: {
   }).trimEnd()
 
   return {
-    title: 'Cloudflare API URL을 이렇게 넣어 주세요',
+    title: 'Cloudflare Worker URL만 채워 주세요',
     body: dedent`
-      Cloudflare Worker \`${options.workerName}\`의 배포 URL을 확인한 뒤 아래 파일에 직접 넣어 주세요.${skippedInitializationBlock}
-
-      ${path.join(options.targetRoot, 'frontend', '.env.local')}
-      MINIAPP_API_BASE_URL=<배포된 Worker URL>${backofficeBlock}
+      ${clientEnvGuidance}
+      Cloudflare Worker \`${options.workerName}\`의 배포 URL만 해당 파일의 빈 값에 채워 주세요.${skippedInitializationBlock}
 
       ${path.join(options.targetRoot, 'server', '.env.local')}
       ${serverEnv}

--- a/packages/create-rn-miniapp/src/templates/index.test.ts
+++ b/packages/create-rn-miniapp/src/templates/index.test.ts
@@ -1600,7 +1600,7 @@ test('applyTrpcWorkspaceTemplate creates shared contracts and app-router workspa
     files?: string[]
     exports?: Record<
       string,
-      { types?: string; import?: string; require?: string; default?: string }
+      string | { types?: string; import?: string; require?: string; default?: string }
     >
     types?: string
     main?: string
@@ -1615,7 +1615,7 @@ test('applyTrpcWorkspaceTemplate creates shared contracts and app-router workspa
     files?: string[]
     exports?: Record<
       string,
-      { types?: string; import?: string; require?: string; default?: string }
+      string | { types?: string; import?: string; require?: string; default?: string }
     >
     types?: string
     main?: string
@@ -1639,6 +1639,12 @@ test('applyTrpcWorkspaceTemplate creates shared contracts and app-router workspa
   ) as {
     targets?: Record<string, { command?: string }>
   }
+  const contractsRootExport = contractsPackageJson.exports?.['.'] as
+    | { types?: string; import?: string; require?: string; default?: string }
+    | undefined
+  const appRouterRootExport = appRouterPackageJson.exports?.['.'] as
+    | { types?: string; import?: string; require?: string; default?: string }
+    | undefined
   const contractsReadme = await readFile(
     path.join(targetRoot, 'packages', 'contracts', 'README.md'),
     'utf8',
@@ -1665,25 +1671,29 @@ test('applyTrpcWorkspaceTemplate creates shared contracts and app-router workspa
   )
   assert.equal(contractsPackageJson.name, '@workspace/contracts')
   assert.deepEqual(contractsPackageJson.files, ['dist'])
-  assert.equal(contractsPackageJson.exports?.['.']?.types, './dist/index.d.mts')
-  assert.equal(contractsPackageJson.exports?.['.']?.import, './dist/index.mjs')
-  assert.equal(contractsPackageJson.exports?.['.']?.require, './dist/index.cjs')
-  assert.equal(contractsPackageJson.exports?.['.']?.default, './dist/index.mjs')
+  assert.equal(contractsRootExport?.types, './dist/index.d.mts')
+  assert.equal(contractsRootExport?.import, './dist/index.mjs')
+  assert.equal(contractsRootExport?.require, './dist/index.cjs')
+  assert.equal(contractsRootExport?.default, './dist/index.mjs')
+  assert.equal(contractsPackageJson.exports?.['./package.json'], './package.json')
   assert.equal(contractsPackageJson.types, './dist/index.d.mts')
   assert.equal(contractsPackageJson.main, './dist/index.cjs')
   assert.equal(contractsPackageJson.dependencies?.zod, '^4.3.6')
   assert.equal(contractsPackageJson.devDependencies?.tsdown, '^0.21.4')
+  assert.equal(contractsPackageJson.devDependencies?.typescript, '^5.9.3')
   assert.equal(appRouterPackageJson.name, '@workspace/app-router')
   assert.deepEqual(appRouterPackageJson.files, ['dist'])
-  assert.equal(appRouterPackageJson.exports?.['.']?.types, './dist/index.d.mts')
-  assert.equal(appRouterPackageJson.exports?.['.']?.import, './dist/index.mjs')
-  assert.equal(appRouterPackageJson.exports?.['.']?.require, './dist/index.cjs')
-  assert.equal(appRouterPackageJson.exports?.['.']?.default, './dist/index.mjs')
+  assert.equal(appRouterRootExport?.types, './dist/index.d.mts')
+  assert.equal(appRouterRootExport?.import, './dist/index.mjs')
+  assert.equal(appRouterRootExport?.require, './dist/index.cjs')
+  assert.equal(appRouterRootExport?.default, './dist/index.mjs')
+  assert.equal(appRouterPackageJson.exports?.['./package.json'], './package.json')
   assert.equal(appRouterPackageJson.types, './dist/index.d.mts')
   assert.equal(appRouterPackageJson.main, './dist/index.cjs')
   assert.equal(appRouterPackageJson.dependencies?.['@trpc/server'], '^11.13.4')
   assert.equal(appRouterPackageJson.dependencies?.['@workspace/contracts'], 'workspace:*')
   assert.equal(appRouterPackageJson.devDependencies?.tsdown, '^0.21.4')
+  assert.equal(appRouterPackageJson.devDependencies?.typescript, '^5.9.3')
   assert.equal(
     contractsPackageJson.scripts?.build,
     'tsdown src/index.ts --format esm,cjs --dts --clean --out-dir dist',

--- a/packages/create-rn-miniapp/src/templates/trpc.ts
+++ b/packages/create-rn-miniapp/src/templates/trpc.ts
@@ -15,6 +15,7 @@ export const TRPC_CLIENT_VERSION = '^11.13.4'
 export const TRPC_SERVER_VERSION = '^11.13.4'
 export const ZOD_VERSION = '^4.3.6'
 export const TSDOWN_VERSION = '^0.21.4'
+export const SHARED_WORKSPACE_TYPESCRIPT_VERSION = '^5.9.3'
 const NX_PROJECT_SCHEMA_URL =
   'https://raw.githubusercontent.com/nrwl/nx/master/packages/nx/schemas/project-schema.json'
 
@@ -115,6 +116,7 @@ function renderContractsPackageJson(packageManager: PackageManager) {
         require: './dist/index.cjs',
         default: './dist/index.mjs',
       },
+      './package.json': './package.json',
     },
     main: './dist/index.cjs',
     types: './dist/index.d.mts',
@@ -128,6 +130,7 @@ function renderContractsPackageJson(packageManager: PackageManager) {
     },
     devDependencies: {
       tsdown: TSDOWN_VERSION,
+      typescript: SHARED_WORKSPACE_TYPESCRIPT_VERSION,
     },
   }
 }
@@ -151,6 +154,7 @@ function renderAppRouterPackageJson(packageManager: PackageManager) {
         require: './dist/index.cjs',
         default: './dist/index.mjs',
       },
+      './package.json': './package.json',
     },
     main: './dist/index.cjs',
     types: './dist/index.d.mts',
@@ -165,6 +169,7 @@ function renderAppRouterPackageJson(packageManager: PackageManager) {
     },
     devDependencies: {
       tsdown: TSDOWN_VERSION,
+      typescript: SHARED_WORKSPACE_TYPESCRIPT_VERSION,
     },
   }
 }


### PR DESCRIPTION
## 요약
- Cloudflare server provider를 붙인 scaffold가 원격 초기화를 건너뛰어도 `frontend/.env.local`, `backoffice/.env.local` placeholder를 자동 생성하도록 수정했습니다.
- Cloudflare+tRPC scaffold가 만드는 `packages/contracts`, `packages/app-router`에 `./package.json` export와 shared `typescript` devDependency를 추가해 RN `ait build`에서 workspace package 해석이 끊기지 않게 맞췄습니다.

## 변경 사항
- `patchFrontendWorkspace`, `patchBackofficeWorkspace`에 provider별 `.env.local` placeholder 생성 helper를 추가했습니다.
- Cloudflare frontend/backoffice 기본 bootstrap과 tRPC bootstrap 테스트에 `.env.local` 생성 계약을 추가했습니다.
- Cloudflare manual setup note title/body를 값 입력 중심으로 바꾸고, generated server README 문구도 같은 계약으로 동기화했습니다.
- tRPC workspace template 테스트에 shared package `exports["./package.json"]`와 `typescript` devDependency 기대값을 먼저 추가했습니다.
- `packages/contracts`, `packages/app-router` template이 모두 `./package.json` export와 shared TypeScript dependency를 렌더하도록 수정했습니다.

## SSoT/정리
- client env ownership은 그대로 각 workspace `.env.local`에 두고, 생성 책임만 provider bootstrap 단계로 당겼습니다.
- provisioning note와 generated README가 서로 다른 계약을 말하던 drift를 정리했습니다.
- `@workspace/app-router` root import 구조는 유지하고, shared package metadata contract만 보강해서 AIT dependency version 수집기와 충돌하던 지점을 없앴습니다.

## Changeset
- `create-rn-miniapp` patch changeset 1개로 이번 두 수정 내용을 함께 정리했습니다.

## 문서 반영
- `docs/ai/Plan.md`에 client env placeholder 누락 수정과 shared workspace package export 회귀 수정 목표/검증 계획을 기록했습니다.
- generated Cloudflare server README 렌더 문구를 placeholder 자동 생성 기준으로 갱신했습니다.

## 검증
- `pnpm --filter create-rn-miniapp test -- --test-name-pattern "applyTrpcWorkspaceTemplate creates shared contracts and app-router workspaces for cloudflare"`
- `pnpm --filter create-rn-miniapp test -- --test-name-pattern "patchFrontendWorkspace adds cloudflare trpc client when trpc overlay is selected|patchCloudflareServerWorkspace wires local worker test config and handler when trpc overlay is selected"`
- fresh scaffold 생성: `node packages/create-rn-miniapp/dist/index.js --package-manager yarn --name trpc-fix-sample --display-name "TRPC Fix Sample" --server-provider cloudflare --trpc --output-dir /tmp/create-rn-miniapp-trpc-fix.vwBHjJ --yes`
- generated sample 검증: `yarn --cwd frontend build`
- `pnpm verify`
